### PR TITLE
V0.3.4 branch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,14 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## v0.3.3 - 2024-07-17
+## Unreleased
+
+## Added
+1. Calculate the no of extensions per row and width of extension_selection_win relative to parent window based on the length of longest extension(`extension_selection_win.py`)
+## Changes from previous release
+1. __Bug Fix__: Modify `extension_selection_win` to resize itself if default value of 7 results in error by calculating the appropriate value of no of extensions per row.
+
+## [0.3.3] - 2024-07-17
 
 ## Added
 1. Create `supported_extensions` file containing the list of supported file formats as specified in https://help.archive.org/help/files-formats-and-derivatives-file-definitions-2/.(`supported_extensions`)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,12 +4,17 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## Unreleased
+## [0.3.4] - 2024-07-22
 
 ## Added
 1. Calculate the no of extensions per row and width of extension_selection_win relative to parent window based on the length of longest extension(`extension_selection_win.py`)
+2. Modify `display_help` function to take only parent_win as argument(`display_help.py`)
+3. Calculate the dimensions of the help window based on the help text(`display_help.py`)
+4. Quit the help window when any key is pressed(`display_help.py`)
+5. Modify `file_browser` to correctly call `display_help`(`file_browser.py`)
 ## Changes from previous release
 1. __Bug Fix__: Modify `extension_selection_win` to resize itself if default value of 7 results in error by calculating the appropriate value of no of extensions per row.
+2. __Bug Fix__: Fix the bug where the help window was not been displayed correctly when `h` was pressed.
 
 ## [0.3.3] - 2024-07-17
 

--- a/Readme.md
+++ b/Readme.md
@@ -120,18 +120,15 @@ We gratefully acknowledge Archive.org for providing extensive archival resources
 ## Changelog
 See the [CHANGELOG.md](https://github.com/bhawesh2002/archive-org-script/blob/main/CHANGELOG.md) file for details on changes and updates.
 
-### Latest Release : [0.3.3](https://github.com/bhawesh2002/archive-org-script/releases/tag/v0.3.3) - 2024-07-17
+### Latest Release : [0.3.4](https://github.com/bhawesh2002/archive-org-script/releases/tag/v0.3.4) - 2024-07-22
 ## Added
-1. Create `supported_extensions` file containing the list of supported file formats as specified in https://help.archive.org/help/files-formats-and-derivatives-file-definitions-2/.(`supported_extensions`)
-2. Use the `supported_extensions` file to extract extensions from filetree.(`extract_extension.py`)
-3. Pass 'extensions' list as a parameter in `extension_selection_window` function.(`extension_selection_win.py`)
-4. Call `extract_extensions` function with in `file_browser`.(`file_browser.py`)
-5. Correctly call `extension_selection_window` function with the `extensions` list as a parameter in `file_browser`.(`file_browser.py`)
-### Changes from Previous Release
-1. __Patch__: Added the list of supported file formats to the `supported_extensions` file as specified in the Archive.org documentation.
-2. __Patch__: Used the `supported_extensions` file to extract extensions from the filetree.
-3. __Bug_Fix__: Passed the `extensions` list as a parameter in the `extension_selection_window` function to improve performance
-4. __Bug_Fix__: Call the `extract_extensions` function in the `file_browser`.
-5. __Bug_Fix__: Correctly called the `extension_selection_window` function with the `extensions` list as a parameter in the `file_browser`.
+1. Calculate the no of extensions per row and width of extension_selection_win relative to parent window based on the length of longest extension(`extension_selection_win.py`)
+2. Modify `display_help` function to take only parent_win as argument(`display_help.py`)
+3. Calculate the dimensions of the help window based on the help text(`display_help.py`)
+4. Quit the help window when any key is pressed(`display_help.py`)
+5. Modify `file_browser` to correctly call `display_help`(`file_browser.py`)
+## Changes from previous release
+1. __Bug Fix__: Modify `extension_selection_win` to resize itself if default value of 7 results in error by calculating the appropriate value of no of extensions per row.
+2. __Bug Fix__: Fix the bug where the help window was not been displayed correctly when `h` was pressed.
 
-### Previous Release : [0.3.2](https://github.com/bhawesh2002/archive-org-script/releases/tag/v0.3.2) - 2024-07-15
+### Previous Release : [0.3.3](https://github.com/bhawesh2002/archive-org-script/releases/tag/v0.3.3) - 2024-07-17

--- a/browsing/file_browser.py
+++ b/browsing/file_browser.py
@@ -21,7 +21,6 @@ def file_browser(stdscr, identifier,filetree):
         main_win.addstr(0,(width - len(title)) // 2,title, curses.color_pair(4) | curses.A_BOLD) #display the title of the window
         main_win.addstr(main_ht-1, 1 , f" {CONTROLS} ", curses.color_pair(5) | curses.A_BOLD) #display the controls
         main_win.refresh() #refresh the window
-        help_required = False #initialize the help status
         #v0.3.3:
         #BugFix: Extract the extensions from the filetree in the file_browser
         extensions = []
@@ -153,9 +152,8 @@ def file_browser(stdscr, identifier,filetree):
                'h' - toggle the help message
             """
             if b_key == ord('h'): #check if the key pressed is 'h' and toggle the help message
-                help_required = not help_required #toggle the help message
-                display_help(main_ht - 2, (main_wt)//3, 1, main_wt - ((main_wt//3) + 2),help_required) #display the help message
-
+                display_help(parent_win=main_win) #display the help message
+                main_win.refresh()
             #Exit controls
             """
             Exit controls:

--- a/displaying/display_help.py
+++ b/displaying/display_help.py
@@ -1,23 +1,58 @@
+# v0.3.4
+# Bug Fix: Modify the display_help function to take a parent window as an argument
+#          Calculate the ddimensions of the help window based on HELP_TEXT
+#          Quit the help window when the user presses any key        
+
+#Old Code:
+#v0.3.3:
+#BugFix: Fix the issue with the display_help function not displaying the help text
+
 import curses
 from colors.app_colors import init_colors
 from constants import HELP_TEXT
 
-def display_help(help_win_ht, help_win_wt, y,x, help_required):
+def display_help(parent_win):
     try: 
-        init_colors()
-        help_win = curses.newwin(help_win_ht, help_win_wt, y, x) #create a new window for displaying help
-        if help_required == True:
+        init_colors() #initialize the color pairs
+
+        #Calculate the dimensions of the help window
+        help_win_wt = len(max(HELP_TEXT, key=len)) + 4 #width of the help window (length of the longest line in the help text + 4 for padding on both sides)
+        help_win_ht = len(HELP_TEXT) + 4 #height of the help window
+        
+        #Calculate the x and y position of the help window
+        parent_win_wt = parent_win.getmaxyx()[1] #get the width of the main window
+        x_pos=parent_win_wt - (help_win_wt + 2) #x position of the help window
+        y_pos=1
+
+        #create a new window for displaying help
+        help_win = curses.newwin(help_win_ht, help_win_wt, y_pos, x_pos) #create a new window for displaying help
+        help_win.refresh()
+        
+        #draw the border
+        help_win.border()
+
+        #display the HELP message
+        help_win.addstr(0, (help_win_wt - len(" HELP "))//2, " HELP ", curses.color_pair(5) | curses.A_BOLD)
+        
+        #display help contents
+        for i,line in enumerate(HELP_TEXT):
+            help_win.addstr(y_pos + i, 2, line, curses.color_pair(5) | curses.A_BOLD)
+
+        #display the PRESS ANY KEY TO CONTINUE... message
+        help_win.addstr(y_pos + len(HELP_TEXT),2, (help_win_wt - 4) * "-", curses.color_pair(5) | curses.A_BOLD)
+        help_win.addstr(y_pos + len(HELP_TEXT) + 1,(help_win_wt//2- (len("PRESS ANY KEY TO CONTINUE...")//2)), "PRESS ANY KEY TO CONTINUE...", curses.color_pair(5) | curses.A_BOLD)
+        
+        help_win.refresh()
+
+        #wait for the user to press a key
+        key = help_win.getch()
+        if key == ord('\033'): #check if the key pressed is 'Esc'
+            help_win.clear()
             help_win.refresh()
-            #display help contents
-            for i,line in enumerate(HELP_TEXT):
-                help_win.addstr(y + i, 0, f"   {line}", curses.color_pair(5))
-            #draw the border
-            help_win.border()
-            #display the help message
-            help_win.addstr(0, (help_win_wt - len("  Help  "))//2, f"  Help  ", curses.color_pair(5) | curses.A_BOLD)
-            help_win.refresh()
-        else :
+            exit(0) #exit the program
+        else:
             help_win.clear() #clear the help window
             help_win.refresh() #refresh the help window
+        
     except Exception as e:
         raise e

--- a/displaying/extension_selection_win.py
+++ b/displaying/extension_selection_win.py
@@ -9,6 +9,7 @@
 
 import copy
 import curses
+from basic_function.extract_extensions import extract_extensions
 from colors.app_colors import init_colors
 from constants import EXTENSION_CONFIRMATION_MESSAGE, EXTENSION_SEL_CONTROLS
 
@@ -26,15 +27,20 @@ def extension_selection_win(parent_win,extensions,stdscr):
         list: The list of selected extensions."""
     try:
         init_colors()
-        exts_per_row = 7 #no of columns/extensions per row
-        no_of_rows= 0
+        
+        #calculate the extensions per row/no of columnss
+        longest_ext_len = len(max(extensions,key=len)) #find the length of longest extension
+        value = ((parent_win.getmaxyx()[1]//(longest_ext_len +  4)))if ((parent_win.getmaxyx()[1]//(longest_ext_len +  4))) > 1 else 2 #calculate value based on longest_ext_len, minimum value should be 2
+        exts_per_row = value if ((longest_ext_len + 4) * 7) > parent_win.getmaxyx()[1] else 7  #set the no of columns/extensions per row to value if longest_ext_len exceeds width of parent win else stick to the default value of 7
+
         #calculate the number of rows
+        no_of_rows= 0
         for i in range(len(extensions)):
             if i%exts_per_row == 0:
                 no_of_rows = no_of_rows + 1
         #calculate the height, width of the extension selection window
-        ext_sel_win_wt = (len(max(extensions,key=len)) + 4) * exts_per_row + 1 #length of the longest extension + 4 padding multiplied by the number of extensions per row
-        ext_sel_win_ht = 2 + no_of_rows + 1 if parent_win.getmaxyx()[0] > (no_of_rows + 3) else parent_win.getmaxyx()[0] - 1 #resize the extension selection window if the height of the parent window is less than the number of rows
+        ext_sel_win_wt = (longest_ext_len + 4) * exts_per_row + 2 #length of the longest extension + 4 padding multiplied by the number of extensions per row plus 2 for spacing
+        ext_sel_win_ht = (2 + no_of_rows + 1) if (parent_win.getmaxyx()[0] > (no_of_rows + 3)) else (parent_win.getmaxyx()[0] - 2) #resize the extension selection window if the height of the parent window is less than the number of rows
         #calculate the y,x position of the extension selection window
         ext_sel_win_y = 1 #y position of the extension selection window
         ext_sel_win_x = (parent_win.getmaxyx()[1] - ext_sel_win_wt)//2 #x position of the extension selection window


### PR DESCRIPTION
## Added
1. Calculate the no of extensions per row and width of extension_selection_win relative to parent window based on the length of longest extension(`extension_selection_win.py`)
2. Modify `display_help` function to take only parent_win as argument(`display_help.py`)
3. Calculate the dimensions of the help window based on the help text(`display_help.py`)
4. Quit the help window when any key is pressed(`display_help.py`)
5. Modify `file_browser` to correctly call `display_help`(`file_browser.py`)
## Changes from previous release
1. __Bug Fix__: Modify `extension_selection_win` to resize itself if default value of 7 results in error by calculating the appropriate value of no of extensions per row.
2. __Bug Fix__: Fix the bug where the help window was not been displayed correctly when `h` was pressed.
